### PR TITLE
Added support for Apple Trailers to userscript

### DIFF
--- a/app/views/config/userscript.js
+++ b/app/views/config/userscript.js
@@ -11,6 +11,7 @@
 // @include     http://whiwa.net/stats/movie/*
 // @include     http://trakt.tv/movie/*
 // @include     http://*.trak.tv/movie/*
+// @include     http://trailers.apple.com/trailers/*
 // @exclude     http://trak.tv/movie/*/*
 // @exclude     http://*.trak.tv/movie/*/*
 // ==/UserScript==
@@ -320,7 +321,7 @@ apple = (function(){
                 response.responseXML = new DOMParser().parseFromString(response.responseText, "text/xml");
             }
 
-            var imdb_id = response.responseXML.getElementsByTagName('imdb_id')[0].firstChild.response; 
+            var imdb_id = response.responseXML.getElementsByTagName('imdb_id')[0].firstChild.nodeValue; 
 
             var year = getYear(response.responseXML);
         }


### PR DESCRIPTION
Don't know what's the strategy for TMDB API keys, so created my own. It would be nice to expose that key in CP admin console, so it can be replaced in userscript.js the same way as host replaced there.
