### PR TITLE
First Lang-support try (at the moment just for the movie-info, other languages can be added within the index.html ...)

### DIFF
--- a/app/config/configApp.py
+++ b/app/config/configApp.py
@@ -103,6 +103,7 @@ class configApp():
 
         self.addSection('TheMovieDB')
         self.setDefault('TheMovieDB', 'key', '9b939aee0aaafc12a65bf448e4af9543')
+		self.setDefault('TheMovieDB', 'language', 'en')
 
         self.addSection('IMDB')
 

--- a/app/config/configApp.py
+++ b/app/config/configApp.py
@@ -103,7 +103,7 @@ class configApp():
 
         self.addSection('TheMovieDB')
         self.setDefault('TheMovieDB', 'key', '9b939aee0aaafc12a65bf448e4af9543')
-		self.setDefault('TheMovieDB', 'language', 'en')
+        self.setDefault('TheMovieDB', 'language', 'en')
 
         self.addSection('IMDB')
 

--- a/app/lib/provider/movie/sources/theMovieDb.py
+++ b/app/lib/provider/movie/sources/theMovieDb.py
@@ -30,7 +30,7 @@ class theMovieDb(movieBase):
 
         log.debug('TheMovieDB - Searching for movie: %s' % q)
 
-        url = "%s/%s/en/xml/%s/%s" % (self.apiUrl, 'Movie.search', self.conf('key'), quote_plus(self.toSearchString(q)))
+        url = "%s/%s/%s/xml/%s/%s" % (self.apiUrl, 'Movie.search', self.conf('language'), self.conf('key'), quote_plus(self.toSearchString(q)))
 
         log.info('Searching: %s' % url)
 
@@ -54,7 +54,7 @@ class theMovieDb(movieBase):
         if self.isDisabled():
             return False
 
-        url = "%s/%s/en/xml/%s/%s" % (self.apiUrl, 'Movie.imdbLookup', self.conf('key'), id)
+        url = "%s/%s/%s/xml/%s/%s" % (self.apiUrl, 'Movie.imdbLookup', self.conf('language'), self.conf('key'), id)
 
         try:
             data = urllib2.urlopen(url, timeout = self.timeout)
@@ -124,7 +124,7 @@ class theMovieDb(movieBase):
         if self.isDisabled():
             return False
 
-        url = "%s/%s/en/xml/%s/%s" % (self.apiUrl, 'Movie.getInfo', self.conf('key'), id)
+        url = "%s/%s/%s/xml/%s/%s" % (self.apiUrl, 'Movie.getInfo', self.conf('language'), self.conf('key'), id)
         data = urllib2.urlopen(url, timeout = self.timeout)
 
         return data

--- a/app/views/config/index.html
+++ b/app/views/config/index.html
@@ -73,6 +73,14 @@
 						Comma seperated. NZB/Torrents must contain these words. Example: GERMAN, DTS
 					</p>
 				</div>
+				<div class="ctrlHolder">
+					<label for="">Movie(-Info) Language</label>
+					<select name="TheMovieDB.language" id="language" class="textInput large">
+						% for language in ['de','en']:
+						<option value="${language}"${' selected="selected"' if str(language) == config.get('TheMovieDB', 'language') else ''}>${language}</option>
+						% endfor
+					</select>
+				</div>
 			</fieldset>
 		</div>
 


### PR DESCRIPTION
I just want to show you how I meant to add the lang-support...
At the moment it's only the movie-info... Because I have to look for a trick to get the german-movie-nzbs via the catIDs ... without changing the catIDs to 2000 (all movie-categories) in the app/lib/provider/yarr/sources/newznab.py like this:

[...]
    catIds = {
        2000: ['brrip'],
        2000: ['dvdr'],
        2000: ['cam', 'ts', 'dvdrip', 'tc', 'r5', 'scr'],
        2000: ['720p', '1080p']
    }
[...]

. So far... I'll try to keep it up... let me know what you think about this.
Greetz, Murkn
