### PR TITLE
Any required words as an extra option

### DIFF
--- a/app/config/configApp.py
+++ b/app/config/configApp.py
@@ -49,6 +49,7 @@ class configApp():
         self.setDefault('global', 'ignoreWords', '')
         self.setDefault('global', 'preferredWords', '')
         self.setDefault('global', 'requiredWords', '')
+        self.setDefault('global', 'anyRequiredWords', '')
 
         self.addSection('Renamer')
         self.setDefault('Renamer', 'enabled', False)

--- a/app/lib/provider/yarr/base.py
+++ b/app/lib/provider/yarr/base.py
@@ -125,6 +125,12 @@ class nzbBase(rss):
             log.info("NZB '%s' contains the following blacklisted words: %s" %
                             (item.name, ", ".join(blacklisted)))
             return False
+			
+		# Use any of the required words instead off all required words
+		anyRequiredWords = get_words(self.config.get('global', 'anyRequiredWords'))
+		requiredWordFound = set(anyRequiredWords).intersection(set(nzbWords))
+		if requiredWordFound:
+			return True
 
         q = Qualities()
         type = q.types.get(qualityType)

--- a/app/lib/provider/yarr/base.py
+++ b/app/lib/provider/yarr/base.py
@@ -125,12 +125,18 @@ class nzbBase(rss):
             log.info("NZB '%s' contains the following blacklisted words: %s" %
                             (item.name, ", ".join(blacklisted)))
             return False
-			
-	# Use any of the required words instead off all required words
-	anyRequiredWords = get_words(self.config.get('global', 'anyRequiredWords'))
-	requiredWordFound = set(anyRequiredWords).intersection(set(nzbWords))
-	if requiredWordFound:
-		return True
+            
+        # Use any of the required words instead off all required words
+        anyRequiredWords = get_words(self.config.get('global', 'anyRequiredWords'))
+        requiredWordFound = set(anyRequiredWords).intersection(set(nzbWords))
+        if requiredWordFound:
+            log.info("NZB '%s' contains the following required word: %s" %
+                            (item.name, ", ".join(requiredWordFound)))
+            return True
+        else:
+            log.info("NZB '%s' contains none of the following required words: %s" %
+                            (item.name, ", ".join(anyRequiredWords)))
+            return False
 
         q = Qualities()
         type = q.types.get(qualityType)

--- a/app/lib/provider/yarr/base.py
+++ b/app/lib/provider/yarr/base.py
@@ -126,11 +126,11 @@ class nzbBase(rss):
                             (item.name, ", ".join(blacklisted)))
             return False
 			
-		# Use any of the required words instead off all required words
-		anyRequiredWords = get_words(self.config.get('global', 'anyRequiredWords'))
-		requiredWordFound = set(anyRequiredWords).intersection(set(nzbWords))
-		if requiredWordFound:
-			return True
+	# Use any of the required words instead off all required words
+	anyRequiredWords = get_words(self.config.get('global', 'anyRequiredWords'))
+	requiredWordFound = set(anyRequiredWords).intersection(set(nzbWords))
+	if requiredWordFound:
+		return True
 
         q = Qualities()
         type = q.types.get(qualityType)

--- a/app/views/config/index.html
+++ b/app/views/config/index.html
@@ -73,6 +73,14 @@
 						Comma seperated. NZB/Torrents must contain these words. Example: GERMAN, DTS
 					</p>
 				</div>
+				
+				<div class="ctrlHolder">
+					<label for="">Any required word</label>
+					<input type="text" name="global.anyRequiredWords" value="${config.get('global', 'anyRequiredWords')}" class="textInput large"/>
+					<p class="formHint">
+						Comma seperated. NZB/Torrents must contain any of these words. Example: WiKi, CtrlHD
+					</p>
+				</div>
 			</fieldset>
 		</div>
 


### PR DESCRIPTION
Wrote on xbmc forum:

> I really like the update with required words, but what I would like is to have an option to use any of the required words and not that just all are required. 
> 
> I want this because I want to download only good encodes and I want to filter on releasegroups. I know I can do this by adding these to preferred words, but then CP already downloads a version which I don't want.

So I did some coding myself. Tested it and it works.
Let me know what you guys think.

Cheers,

Bor
