### PR TITLE
Some small fixes to couchpotato

### DIFF
--- a/app/lib/cron/subtitle.py
+++ b/app/lib/cron/subtitle.py
@@ -43,6 +43,15 @@ class SubtitleCron(rss, cronBase, Library):
             except Queue.Empty:
                 pass
 
+        # Subtitle providers are done for now, so close them if necessary.
+        # This prevents this cron from hanging on to a socket in between
+        # runs, and trying to re-use it on the next run. Often the other 
+        # side of the socket will close it if it is unused for a long period 
+        # of time, making it unusable anyway.
+        for provider in self.providers:
+            if hasattr(provider, 'close') and callable(provider.close):
+                provider.close()
+
         log.info('SubtitleCron shutting down.')
 
     def conf(self, value):

--- a/app/lib/library.py
+++ b/app/lib/library.py
@@ -444,7 +444,7 @@ class Library:
         libraryDir = os.path.join(cherrypy.config.get('basePath'), 'library')
         script = os.path.join(libraryDir, 'getmeta.py')
 
-        p = subprocess.Popen(["python", script, filename], stdout = subprocess.PIPE, stderr = subprocess.PIPE, cwd = libraryDir)
+        p = subprocess.Popen(["python2", script, filename], stdout = subprocess.PIPE, stderr = subprocess.PIPE, cwd = libraryDir)
         z = p.communicate()[0]
 
         try:

--- a/app/lib/library.py
+++ b/app/lib/library.py
@@ -65,7 +65,15 @@ class Library:
             return movies
 
         log.debug('os.walk(movieFolder) %s' % movieFolder)
-        for root, subfiles, filenames in os.walk(movieFolder):
+        # Walk the tree once to catch any UnicodeDecodeErrors that might arise
+        # from malformed file and directory names. Use the non-unicode version
+        # of movieFolder if so.
+        try:
+            for x in os.walk(movieFolder): pass
+            walker = os.walk(movieFolder)
+        except UnicodeDecodeError:
+            walker = os.walk(str(movieFolder))
+        for root, subfiles, filenames in walker:
             if self.abort:
                 log.debug('Aborting moviescan')
                 return movies

--- a/app/lib/library.py
+++ b/app/lib/library.py
@@ -452,7 +452,12 @@ class Library:
         libraryDir = os.path.join(cherrypy.config.get('basePath'), 'library')
         script = os.path.join(libraryDir, 'getmeta.py')
 
-        p = subprocess.Popen(["python2", script, filename], stdout = subprocess.PIPE, stderr = subprocess.PIPE, cwd = libraryDir)
+        # Use the current python interpreter, if possible. Cannot rely on just using "python" because on some
+        # system (ie. ArchLinux), the default "python" interpreter is python 3, and that will not work here.
+        pyinterp = sys.executable
+        if not pyinterp: pyinterp = "python"
+
+        p = subprocess.Popen([pyinterp, script, filename], stdout = subprocess.PIPE, stderr = subprocess.PIPE, cwd = libraryDir)
         z = p.communicate()[0]
 
         try:

--- a/app/lib/library.py
+++ b/app/lib/library.py
@@ -21,7 +21,7 @@ class Library:
     ignoredInPath = ['_unpack', '_failed_', '_unknown_', '_exists_', '.appledouble', '.appledb', '.appledesktop', '/._', 'cp.cpnfo'] #unpacking, smb-crap, hidden files
     ignoreNames = ['extract', 'extracting', 'extracted', 'movie', 'movies', 'film', 'films']
     extensions = {
-        'movie': ['*.mkv', '*.wmv', '*.avi', '*.mpg', '*.mpeg', '*.mp4', '*.m2ts', '*.iso', '*.img', '*.vob'],
+        'movie': ['*.mkv', '*.wmv', '*.avi', '*.mpg', '*.mpeg', '*.mp4', '*.m4v', '*.m2ts', '*.iso', '*.img', '*.vob'],
         'nfo': ['*.nfo'],
         'subtitle': ['*.sub', '*.srt', '*.ssa', '*.ass'],
         'subtitleExtras': ['*.idx'],

--- a/app/lib/provider/subtitle/sources/opensubtitles.py
+++ b/app/lib/provider/subtitle/sources/opensubtitles.py
@@ -24,8 +24,6 @@ class openSubtitles(subtitleBase):
         self.config = config
         self.extensions = extensions
 
-        self.login()
-
     def conf(self, value):
         return self.config.get('Subtitles', value)
 
@@ -47,9 +45,14 @@ class openSubtitles(subtitleBase):
 
         return True;
 
+    def close(self):
+        if self.token:
+            self.server.close()
+            self.token = None
+
     def find(self, movie):
 
-        if not self.isAvailable(self.siteUrl) and self.login():
+        if not (self.isAvailable(self.siteUrl) and self.login()):
             return
 
         data = {


### PR DESCRIPTION
Hello.

I've been enjoying your CouchPotato application for a month or so now, and find it very useful. Thank you for creating it.

I've made a couple of small fixes to your codebase you may be interested in

1) opensubtitles.org xmlrpc connection was trying to be reused between subtitle cron runs, but more likely this would get closed by the remote side, leaving the socket in a CLOSE_WAIT state, and not reusable. Added a close() after all of the subtitle sources are run, to clean this up and force the connection to be re-established on the next run.

2) Spawning the getmeta.py script using just the "python" interpreter would not work when the default version of python is python 2, like on my ArchLinux system.  Changed this to use the sys.executable value, with a fallback to just "python" if that doesn't make sense.

3) Sometimes files downloaded contain non-unicode conforming characters. In app.lib.library.getMovies(), if the os.walk() encountered such a file it would throw a UnicodeDecodeError. Handle this by wrapping an os.walk() in a try/catch and use a non-unicode parameter to os.walk() instead.

4) Added the "m4v" extension to the live of movie extensions in app.lib.library.Library class.

I hope you find these useful.

Cheers,
- Mark Crewson
