### PR TITLE
fix for issue #201, prevent renamer cleanup from deleting d/l folder

### DIFF
--- a/app/lib/cron/renamer.py
+++ b/app/lib/cron/renamer.py
@@ -205,6 +205,10 @@ class RenamerCron(cronBase, Library):
                     for dir in os.path.split(root):
                         if dir in self.ignoreNames:
                             skip = True
+                            
+                    # ignore if the current dir is the blackhole
+                    if root in self.conf('download'):
+                        skip = True
 
                     if skip: continue
 


### PR DESCRIPTION
I have added a simple check that will stop the renamer job from removing the current folder if it is the movie download folder. i managed to replicate the issue and this fix has prevented it. 

this issue did only occur when the movie file was in the root of the download folder and not in a sub directory
