### PR TITLE
Disable MovieETA checking

### DIFF
--- a/app/config/configApp.py
+++ b/app/config/configApp.py
@@ -123,6 +123,9 @@ class configApp():
         self.setDefault('Subtitles', 'languages', 'en')
         self.setDefault('Subtitles', 'addLanguage', True)
         self.setDefault('Subtitles', 'name', 'filename') #filename, subtitle
+        
+        self.addSection('MovieETA')
+        self.setDefault('MovieETA', 'enabled', True)
 
         self.addSection('MovieRSS')
         self.setDefault('MovieRSS', 'enabled', False)

--- a/app/controllers/config.py
+++ b/app/controllers/config.py
@@ -66,6 +66,7 @@ class ConfigController(BaseController):
               'GROWL.enabled', 'GROWL.onSnatch',
               'Notifo.enabled', 'Notifo.onSnatch',
               'Meta.enabled',
+              'MovieETA.enabled',
               'Renamer.enabled', 'Renamer.trailerQuality', 'Renamer.cleanup',
               'Torrents.enabled',
               'NZB.enabled',

--- a/app/lib/cron/eta.py
+++ b/app/lib/cron/eta.py
@@ -26,6 +26,13 @@ class etaCron(rss, cronBase):
 
         timeout = 0.1 if self.debug else 1
         while True and not self.abort:
+            
+            config = cherrpy.config.get('config')
+            
+            if not config.get('MovieETA','enabled'):
+                log.info('MovieETA disabled')
+                break
+            
             try:
                 queue = etaQueue.get(timeout = timeout)
                 if queue.get('id'):

--- a/app/views/config/index.html
+++ b/app/views/config/index.html
@@ -530,6 +530,13 @@
 					</p>
 				</div>
 			</fieldset>
+			<fieldset class="inlineLabels">
+				<h3>MovieETA</h3>
+				<div class="ctrlHolder checkbox">
+					<label>Check VideoETA</label>
+					<input type="checkbox" name="MovieETA.enabled" value="True" ${' checked="checked"' if config.get('MovieETA', 'enabled') else ''} />
+				</div>
+			</fieldset>
 		</div>
 		<div class="group notifications">
 			<fieldset class="inlineLabels" id="xbmcFieldset">


### PR DESCRIPTION
not sure how well it works! needs testing.

this adds a boolean option (enabled by default!!) that allows the videoeta search to be skipped
the option is on the config/extra page
