### PR TITLE
Better nzbget error handling and default nzbget postprocessing support

### DIFF
--- a/app/lib/library.py
+++ b/app/lib/library.py
@@ -18,7 +18,7 @@ class Library:
         self.config = cherrypy.config.get('config')
 
     minimalFileSize = 1024 * 1024 * 200 # 10MB
-    ignoredInPath = ['_unpack', '_failed_', '_unknown_', '_exists_', '.appledouble', '.appledb', '.appledesktop', '/._', 'cp.cpnfo'] #unpacking, smb-crap, hidden files
+    ignoredInPath = ['extracted', '_unpack', '_failed_', '_unknown_', '_exists_', '.appledouble', '.appledb', '.appledesktop', '/._', 'cp.cpnfo'] #unpacking, smb-crap, hidden files
     ignoreNames = ['extract', 'extracting', 'extracted', 'movie', 'movies', 'film', 'films']
     extensions = {
         'movie': ['*.mkv', '*.wmv', '*.avi', '*.mpg', '*.mpeg', '*.mp4', '*.m4v', '*.m2ts', '*.iso', '*.img', '*.vob'],

--- a/app/lib/nzbget.py
+++ b/app/lib/nzbget.py
@@ -1,5 +1,5 @@
 from app.config.cplog import CPLog
-import httplib
+import socket
 
 from base64 import standard_b64encode
 import xmlrpclib
@@ -26,9 +26,6 @@ class nzbGet():
             return False
 
         nzbGetXMLrpc = "http://nzbget:%(password)s@%(host)s/xmlrpc"
-        if self.conf('host') == None:
-            log.error("No nzbGet host found in configuration. Please configure it.")
-            return False
 
         url = nzbGetXMLrpc % {"host": self.conf('host'), "password": self.conf('password')}
 
@@ -38,11 +35,11 @@ class nzbGet():
                 log.info("Successfully connected to nzbGet")
             else:
                 log.info("Successfully connected to nzbGet, but unable to send a message")
-        except httplib.socket.error:
-            log.error("nzbGet is not responding. Please ensure that nzbGet is running and that your password and host is correct.")
+        except socket.error:
+            log.error("nzbGet is not responding. Please ensure that nzbGet is running and host setting is correct.")
             return False
         except xmlrpclib.ProtocolError, e:
-            if e.errmsg == "Unauthorized":
+            if e.errcode == 401:
                 log.error("nzbGet password is incorrect.")
             else:
                 log.error("Protocol Error: " + e.errmsg)
@@ -52,6 +49,7 @@ class nzbGet():
             r = urllib2.urlopen(nzb.url).read().strip()
         except:
             log.error("Unable to get NZB file.")
+            return False
 
         nzbcontent64 = standard_b64encode(r)
 


### PR DESCRIPTION
Removed some redundant code for host checking and better error handling code.

Also I added extracted to the ignoreinPath It is used by the default nzbget postprocessing script (created in the downloaded folder)
This fixes bugs: #91, #93 and #231

The only problem is, it might conflict with http://www.imdb.com/title/tt1757746/ (Extracted 2011)
But thats actually currently also a problem, as extracted is in ignoreNames
so it is up to you Ruud if you want the second commit aswell...
