### PR TITLE
Lighttpd reverse proxy fix

### DIFF
--- a/CouchPotato.py
+++ b/CouchPotato.py
@@ -194,7 +194,7 @@ def server_start():
     #cherrypy.log.access_log.propagate = False
 
     #No Root controller as we provided all our own.
-    cherrypy.tree.mount(root = None, config = conf)
+    cherrypy.tree.mount(None, cherrypy.config.get('config').get('global', 'urlbase'), config = conf)
 
     #HTTP Errors
     def http_error_hander(status, message, traceback, version):

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -13,10 +13,6 @@ def url(*args, **kwargs):
     return routes.url_for(*args, **kwargs)
 
 def redirect(url):
-    b = base()
-    if b and not url.startswith(('http://', 'https://')):
-        url = url[len(b) + 1:] if url.startswith(b) else url
-        url = '/' + url if url else b
     raise cherrypy.HTTPRedirect(url)
 
 class BaseController:

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -10,7 +10,7 @@ def base():
     return ''
 
 def url(*args, **kwargs):
-    return cherrypy.url(routes.url_for(*args, **kwargs), base = base())
+    return routes.url_for(*args, **kwargs)
 
 def redirect(url):
     b = base()


### PR DESCRIPTION
This changes cherrypy to use a mount location other than /, and then removes some code that adds a base url on your own. I don't know if this breaks anything, but I did snatch a movie. Mostly I'm worried about apache reverse proxying.

It still has an error if you go to
http://server/base

http://server/base/ works, and so does http://server/base/movie/
