### PR TITLE
nzbget fixed

### DIFF
--- a/app/lib/nzbget.py
+++ b/app/lib/nzbget.py
@@ -45,8 +45,22 @@ class nzbGet():
                 log.error("Protocol Error: " + e.errmsg)
             return False
 
+        newzbinuser = self.config.get('newzbin', 'username')
+        newzbinpass = self.config.get('newzbin', 'password')
+
         try:
-            r = urllib2.urlopen(nzb.url).read().strip()
+            if nzb.source == 'newzbin':
+                newzbinurl = 'http://www.newzbin.com/api/dnzb/'
+                newzbinargs = { 'username' : newzbinuser,
+                                'password' : newzbinpass,
+                                'reportid' : str(nzb.id) }
+                log.info('Receiving report ' + str(nzb.id) + ' from newzbin')
+                newzbindata = urllib.urlencode(newzbinargs)
+                nzburl = urllib2.Request(newzbinurl, newzbindata)
+            else:
+                log.error('Downloading '+nzb.url)
+                nzburl = nzb.url
+            r = urllib2.urlopen(nzburl).read().strip()
         except:
             log.error("Unable to get NZB file.")
             return False

--- a/app/lib/provider/yarr/sources/newzbin.py
+++ b/app/lib/provider/yarr/sources/newzbin.py
@@ -117,6 +117,7 @@ class newzbin(nzbBase):
                     new = self.feedItem()
                     new.id = id
                     new.type = 'nzb'
+                    new.source = 'newzbin'
                     new.name = title
                     new.date = int(time.mktime(parse(date).timetuple()))
                     new.size = self.parseSize(size)


### PR DESCRIPTION
Tweaked the nzbget plugin to download from the DNZB API for newzbin posts. Should fix the issues with newzbin for nzbget users. I guess a similar fix could be applied to the blackhole method..
