### PR TITLE
A fix for a twitter oauth edge case

### DIFF
--- a/app/controllers/config.py
+++ b/app/controllers/config.py
@@ -198,6 +198,9 @@ class ConfigController(BaseController):
         twitter = Twitter()
         referer = cherrypy.request.headers.get('referer')
         auth_url = twitter.get_authorization(referer)
+        if not auth_url:
+          return ('Error making an oauth connection to Twitter.  Check your '
+                  'system time?  See the logs for a more detailed error.')
         return redirect(auth_url)
 
     @cherrypy.expose

--- a/app/lib/twitter.py
+++ b/app/lib/twitter.py
@@ -74,7 +74,7 @@ class Twitter:
         resp, content = oauth_client.request(self.REQUEST_TOKEN_URL, 'POST', body=urllib.urlencode({'oauth_callback':callbackURL}))
 
         if resp['status'] != '200':
-            log.error('Invalid response from Twitter requesting temp token: %s' % resp['status'])
+            log.error('Invalid response from Twitter requesting temp token: %s: %s' % (resp['status'], content))
         else:
             request_token = dict(parse_qsl(content))
 


### PR DESCRIPTION
If the system time is off, CouchPotato will fail to get the oauth token from
twitter at twitter.py, line 74.  twitter.get_authentication then returns None,
ultimately causing a traceback when the code tries to iterate None and fails.

This handles the case where oauth fails more gracefully, and provides a hint to
the user about how to fix the problem.
