### PR TITLE
Updated Boxcar notifier to work with latest API changes which eliminate password auth

### DIFF
--- a/app/config/configApp.py
+++ b/app/config/configApp.py
@@ -209,7 +209,6 @@ class configApp():
         self.setDefault('Boxcar', 'enabled', False)
         self.setDefault('Boxcar', 'onSnatch', False)
         self.setDefault('Boxcar', 'username', '')
-        self.setDefault('Boxcar', 'password', '')
 
         self.addSection('NMA')
         self.setDefault('NMA', 'enabled', False)

--- a/app/controllers/config.py
+++ b/app/controllers/config.py
@@ -177,7 +177,7 @@ class ConfigController(BaseController):
     def testBoxcar(self, **data):
 
         boxcar = Boxcar()
-        boxcar.test(data.get('Boxcar.username'), data.get('Boxcar.password'))
+        boxcar.test(data.get('Boxcar.username'))
 
         return ''
     

--- a/app/lib/boxcar.py
+++ b/app/lib/boxcar.py
@@ -41,10 +41,11 @@ class Boxcar:
                 raise Exception
 
         except Exception, e:
-            print 'Boxcar notification failed.'
+            log.info(e)
+            log.error('Boxcar notification failed.')
             return False
 
-        print 'Boxcar notification successful.'
+        log.info('Boxcar notification successful.')
         return
 
     def notify(self, message, status):

--- a/app/lib/boxcar.py
+++ b/app/lib/boxcar.py
@@ -5,52 +5,46 @@ import json
 import urllib
 import urllib2
 import time
+import platform 
 
 log = CPLog(__name__)
 
 class Boxcar:
 
     username = ''
-    password = ''
 
     def __init__(self):
         self.enabled = self.conf('enabled')
         self.username = self.conf('username')
-        self.password = self.conf('password')
         pass
 
     def conf(self, options):
         return cherrypy.config['config'].get('Boxcar', options)
 
     def send(self, message, status):
-
-        url = 'https://boxcar.io/notifications'
-
+        boxcar_provider_key = '7MNNXY3UIzVBwvzkKwkC' #default for provider as given by Boxcar when CouchPotato was registered
+        url = 'https://boxcar.io/devices/providers/' + boxcar_provider_key + '/notifications'
         try:
             message = message.strip()
             data = urllib.urlencode({
-                'notification[from_screen_name]': self.username,
+                'email': self.username,
+                'notification[from_screen_name]': 'CouchPotato running on ' + platform.uname()[1],
                 'notification[message]': message.encode('utf-8'),
                 'notification[from_remote_service_id]': int(time.time()),
-                'notification[source_url]' : 'nas.local'
             })
 
             req = urllib2.Request(url)
-	    authHeader = "Basic %s" % base64.encodestring('%s:%s' % (self.username, self.password))[:-1]
-	    req.add_header("Authorization", authHeader)
-	    
-            handle = urllib2.urlopen(req, data)
-            result = json.load(handle)
 
-            if result['status'] != 'success' or result['response_message'] != 'OK':
+            handle = urllib2.urlopen(req, data)
+            result = handle.info()
+            if result['status'] != '200':
                 raise Exception
 
         except Exception, e:
-            log.info(e)
-            log.error('Boxcar notification failed.')
+            print 'Boxcar notification failed.'
             return False
 
-        log.info('Boxcar notification successful.')
+        print 'Boxcar notification successful.'
         return
 
     def notify(self, message, status):
@@ -59,10 +53,8 @@ class Boxcar:
 
         self.send(message, status)
 
-    def test(self, username, password):
-
+    def test(self, username):
         self.enabled = True
         self.username = username
-        self.password = password
 
         self.notify('This is a test notification from Couch Potato', "Testing:")

--- a/app/views/config/index.html
+++ b/app/views/config/index.html
@@ -938,10 +938,6 @@
 					<input type="text" name="Boxcar.username" value="${config.get('Boxcar', 'username')}" class="textInput large" />
 				</div>
 				<div class="ctrlHolder">
-					<label>Password</label>
-					<input type="text" name="Boxcar.password" value="${config.get('Boxcar', 'password')}" class="textInput large" />
-				</div>
-				<div class="ctrlHolder">
 					<a href="#boxcarTest" id="boxcarTest" class="testNotification">Send a message to Boxcar, see if it works.</a>
 				</div>
 			</fieldset>


### PR DESCRIPTION
The newest version of Boxcar API simply requires a provider to have a registered key, and then that key when combined with the email of the user who wishes to receive notifications results in the message being delivered.

I already put in a registration request for CouchPotato with Boxcar, and the key used in the /app/lib/boxcar.py reflects this new key.   Once Boxcar authorizes the new provider my changes should allow anyone to use the Boxcar notifier.   I submitted the request on December 11, 2011.   With luck they will quickly authorize the addition.   I will update this pull request when they have done so to indicate that the code is fully safe to use.

A user will simply need to have or create a Boxcar account, add the CouchPotato Service Provider from the Provider screen, enable the notifier in CouchPotato, and enter the email account they use as a username with Boxcar.
