### PR TITLE
--nolaunch commandline option

### DIFF
--- a/initd.ubuntu
+++ b/initd.ubuntu
@@ -69,7 +69,7 @@ load_settings() {
             return 1; }
         [ -z "${RUN_AS%:*}" ] && exit 1
 
-        DAEMON_OPTS="CouchPotato.py --quiet -d"
+        DAEMON_OPTS="CouchPotato.py --quiet -d --nolaunch"
         [ -n "$CONFIG" ] && DAEMON_OPTS="$DAEMON_OPTS --config=$CONFIG"
         [ -z "$CONFIG" ] && DAEMON_OPTS="$DAEMON_OPTS --config=/home/$RUN_AS/.couchpotato/config.ini"
         [ -n "$DATADIR" ] && DAEMON_OPTS="$DAEMON_OPTS --datadir=$DATADIR"


### PR DESCRIPTION
Don't launch browser (especially when setting up daemons on headless server this prevents errors on clean install.

Also,
console was always quiet, even when daemon and quiet were not set. Fixed that too. Apparantly consolelogging is by default false instead of true.
