### PR TITLE
Fix efnet and mysterbin nzb grabbing

### DIFF
--- a/app/lib/provider/yarr/sources/mysterbin.py
+++ b/app/lib/provider/yarr/sources/mysterbin.py
@@ -35,7 +35,12 @@ class mysterbin(torrentBase):
 
         url = self.searchUrl % quote_plus(self.toSearchString(movie.name + ' ' + quality))
         log.info('Searching: %s' % url)
-        data = urllib.urlopen(url)
+
+        try:
+            data = urllib2.urlopen(url, timeout = self.timeout).read()
+        except (IOError, URLError):
+            log.error('Failed to open %s.' % url )
+            return results
   
         try:
             tables = SoupStrainer('table')

--- a/app/lib/provider/yarr/sources/x264.py
+++ b/app/lib/provider/yarr/sources/x264.py
@@ -34,7 +34,12 @@ class x264(torrentBase):
 
         url = self.searchUrl % quote_plus(self.toSearchString(movie.name + ' ' + quality))
         log.info('Searching: %s' % url)
-        data = urllib.urlopen(url)
+
+        try:
+            data = urllib2.urlopen(url, timeout = self.timeout).read()
+        except (IOError, URLError):
+            log.error('Failed to open %s.' % url )
+            return results
 
         try:
             tables = SoupStrainer('table')


### PR DESCRIPTION
URL didn't return correct with urllib.urlopen - changed to urllib2.urlopen().read() and it grabs files correctly.
