### PR TITLE
Add compatibility with both new and old DTD's

### DIFF
--- a/app/lib/provider/yarr/sources/newzbin.py
+++ b/app/lib/provider/yarr/sources/newzbin.py
@@ -16,6 +16,8 @@ class newzbin(nzbBase):
     name = 'Newzbin'
     searchUrl = 'https://www.newzbin2.es/search/'
     downloadUrl = 'http://www.newzbin2.es/api/dnzb/'
+    REPORT_NS_OLD = 'http://www.newzbin.com/DTD/2007/feeds/report/'
+    REPORT_NS = 'http://www.newzbin2.es/DTD/2007/feeds/report/'
 
     formatIds = {
         2: ['scr'],
@@ -107,12 +109,13 @@ class newzbin(nzbBase):
                     title = self.gettextelement(item, "title")
                     if 'error' in title.lower(): continue
 
-                    REPORT_NS = 'http://www.newzbin.com/DTD/2007/feeds/report/';
-
-                    # Add attributes to name
-                    for attr in item.find('{%s}attributes' % REPORT_NS):
+                    try:
+                      for attr in item.find('{%s}attributes' % self.REPORT_NS):
                         title += ' ' + attr.text
-
+                    except:
+                      for attr in item.find('{%s}attributes' % self.REPORT_NS_OLD):
+                        title += ' ' + attr.text
+                    
                     id = int(self.gettextelement(item, '{%s}id' % REPORT_NS))
                     size = str(int(self.gettextelement(item, '{%s}size' % REPORT_NS)) / 1024 / 1024) + ' mb'
                     date = str(self.gettextelement(item, '{%s}postdate' % REPORT_NS))


### PR DESCRIPTION
Hello Ruud,

Newzbin is about to permanently switch their DTD to newzbin2.es, however they've temporarily reverted their change back to newzbin.com.

My change allows both DTD's to be accepted. The parser will attempt to use the newzbin2.es domain first, and fall back on newzbin.com

Regards
drok
