### PR TITLE
Add compatibility with both new and old DTD's

### DIFF
--- a/app/lib/provider/yarr/sources/newzbin.py
+++ b/app/lib/provider/yarr/sources/newzbin.py
@@ -16,6 +16,8 @@ class newzbin(nzbBase):
     name = 'Newzbin'
     searchUrl = 'https://www.newzbin2.es/search/'
     downloadUrl = 'http://www.newzbin2.es/api/dnzb/'
+    REPORT_NS_OLD = 'http://www.newzbin.com/DTD/2007/feeds/report/'
+    REPORT_NS = 'http://www.newzbin2.es/DTD/2007/feeds/report/'
 
     formatIds = {
         2: ['scr'],
@@ -107,12 +109,15 @@ class newzbin(nzbBase):
                     title = self.gettextelement(item, "title")
                     if 'error' in title.lower(): continue
 
-                    REPORT_NS = 'http://www.newzbin.com/DTD/2007/feeds/report/';
-
-                    # Add attributes to name
-                    for attr in item.find('{%s}attributes' % REPORT_NS):
+                    try:
+                      for attr in item.find('{%s}attributes' % self.REPORT_NS):
                         title += ' ' + attr.text
-
+                        REPORT_NS = self.REPORT_NS
+                    except:
+                      for attr in item.find('{%s}attributes' % self.REPORT_NS_OLD):
+                        title += ' ' + attr.text
+                        REPORT_NS = self.REPORT_NS_OLD
+                    
                     id = int(self.gettextelement(item, '{%s}id' % REPORT_NS))
                     size = str(int(self.gettextelement(item, '{%s}size' % REPORT_NS)) / 1024 / 1024) + ' mb'
                     date = str(self.gettextelement(item, '{%s}postdate' % REPORT_NS))


### PR DESCRIPTION
Hello Ruud,

Newzbin will be permanently changing their DTD to newzbin2.es, but they have temporarily reverted this un-announced change to allow time for a proper announcement.

This change makes CP accept both newzbin.com and newzbin2.es DTD's, so when newzbin finally makes their change, it will be a transparent change to users with updated software.

Regards,
drok
