### PR TITLE
Update app/lib/provider/yarr/sources/newzbin.py

### DIFF
--- a/app/lib/provider/yarr/sources/newzbin.py
+++ b/app/lib/provider/yarr/sources/newzbin.py
@@ -142,7 +142,7 @@ class newzbin(nzbBase):
 
                 return results
             except:
-                log.error('Failed to parse XML response from newzbin.com: %s' % traceback.format_exc())
+                log.error('Failed to parse XML response from newzbin2.es: %s' % traceback.format_exc())
 
         return results
 


### PR DESCRIPTION
Logmessage now says newzbin2.es instead of newzbin.com
