### PR TITLE
Fix NZBsRUS provider

### DIFF
--- a/app/lib/provider/yarr/search.py
+++ b/app/lib/provider/yarr/search.py
@@ -5,6 +5,7 @@ from app.lib.provider.yarr.sources.newzbin import newzbin
 from app.lib.provider.yarr.sources.nzbs import nzbs
 from app.lib.provider.yarr.sources.tpb import tpb
 from app.lib.provider.yarr.sources.x264 import x264
+from app.lib.provider.yarr.sources.nzbsrus import nzbsRus
 from app.lib.qualities import Qualities
 from urllib2 import URLError
 import time
@@ -21,7 +22,7 @@ class Searcher():
         self.config = config
         self.debug = debug
 
-        for yarr in [newzbin, nzbMatrix, nzbs, newznab, tpb, x264]:
+        for yarr in [newzbin, nzbMatrix, nzbs, newznab, tpb, x264, nzbsRus]:
             m = yarr(config)
             self.sources.append(m)
 

--- a/app/lib/provider/yarr/sources/nzbsrus.py
+++ b/app/lib/provider/yarr/sources/nzbsrus.py
@@ -120,7 +120,7 @@ class nzbsRus(nzbBase):
                     new.score = self.calcScore(new, movie)
                     new.checkNZB = True
 
-                    if self.isCorrectMovie(new, movie, type, imdbResults = True):
+                    if self.isCorrectMovie(new, movie, type):
                         results.append(new)
                         log.info('Found: %s' % new.name)
 


### PR DESCRIPTION
Hi Ruud, 

Great job with CP! I'm a huge fan.

I was having some problems using NZBsRUS as a search provider. Once I wired it into `search.py` I found that it came up with many false matches. I followed the other providers to resolve the issue. After manual testing,  NZBsRUS searching works great with these changes.
