### PR TITLE
Added Plex-style file stacking patterns for renamer

### DIFF
--- a/app/controllers/config.py
+++ b/app/controllers/config.py
@@ -33,6 +33,8 @@ class ConfigController(BaseController):
         replacements = {
              'cd': ' cd1',
              'cdNr': ' 1',
+             'pt': ' pt1',
+             'part': ' part1',
              'ext': 'mkv',
              'namethe': 'Big Lebowski, The',
              'thename': 'The Big Lebowski',

--- a/app/lib/cron/renamer.py
+++ b/app/lib/cron/renamer.py
@@ -311,6 +311,8 @@ class RenamerCron(cronBase, Library):
         replacements = {
              'cd': '',
              'cdNr': '',
+             'pt': '',
+             'part': '',
              'ext': 'mkv',
              'namethe': namethe.strip(),
              'thename': moviename.strip(),
@@ -354,6 +356,8 @@ class RenamerCron(cronBase, Library):
             if multiple:
                 replacements['cd'] = ' cd' + str(cd)
                 replacements['cdNr'] = ' ' + str(cd)
+                replacements['pt'] = ' pt' + str(cd)
+                replacements['part'] = ' part' + str(cd)
 
             replacements['original'] = file['filename']
 

--- a/app/views/config/index.html
+++ b/app/views/config/index.html
@@ -272,6 +272,8 @@
 						Only with multiple files:
 						<span><strong>cd</strong>: cd1</span>
 						<span><strong>cdNr</strong>: 1</span>
+						<span><strong>pt</strong>: pt1</span>
+						<span><strong>part</strong>: part1</span>
 					</p>
 				</div>
 				<div class="ctrlHolder checkbox">


### PR DESCRIPTION
Good evening!

I added a small enhancement to the CP renaming functionality and configuration to enable Plex users with the choice of all supported file stacking patterns, per the Plex documentation:

http://wiki.plexapp.com/index.php/PlexNine_PMS_Naming_Guide#Stacked_Files

Thanks for an awesome product!

Chris Hamilton
