### PR TITLE
Allow more flexibility with imdb watchlist URLs 

### DIFF
--- a/app/lib/imdbwl.py
+++ b/app/lib/imdbwl.py
@@ -30,7 +30,7 @@ class ImdbWl:
             # Check if user has provided watchlist webpage, rather than export URL
             try:
                 url_parts = url.split("/")
-                if url_parts[3] == "user" or url_parts[5] == "watchlist":
+                if url_parts[3] == "user" and url_parts[5].startswith("watchlist"):
                     url = "http://www.imdb.com/list/export?list_id=watchlist&author_id=%s" % (url_parts[4])
             except(IndexError):
                 pass

--- a/app/lib/imdbwl.py
+++ b/app/lib/imdbwl.py
@@ -27,6 +27,14 @@ class ImdbWl:
                 log.info('Incorrect IMDB watchlist URL: %s. Skipping.' % url)
                 return temp_wl
 
+            # Check if user has provided watchlist webpage, rather than export URL
+            try:
+                url_parts = url.split("/")
+                if url_parts[3] == "user" or url_parts[5] == "watchlist":
+                    url = "http://www.imdb.com/list/export?list_id=watchlist&author_id=%s" % (url_parts[4])
+            except(IndexError):
+                pass
+
             urllib._urlopener = ImdbUrlOpener()
             tmp_csv, headers = urllib.urlretrieve(url)
             csvwl = csv.reader(open(tmp_csv, 'rb'))


### PR DESCRIPTION
Currently the imdb watchlist url feature only supports the specific export link.  To reduce confusion, now if the user pastes their watchlist URL like:

http://www.imdb.com/user/ur22103095/watchlist?publish=save&sort=listorian:asc&view=detail 
or
http://www.imdb.com/user/ur22103095/watchlist

These links will also work for importing movies.
