### PR TITLE
Newsnab: Multiple categories have similar quality content. 1080p is not only available in 2040.

### DIFF
--- a/app/config/configApp.py
+++ b/app/config/configApp.py
@@ -49,6 +49,7 @@ class configApp():
         self.setDefault('global', 'ignoreWords', '')
         self.setDefault('global', 'preferredWords', '')
         self.setDefault('global', 'requiredWords', '')
+        self.setDefault('global', 'reqregex', '')
 
         self.addSection('Renamer')
         self.setDefault('Renamer', 'enabled', False)

--- a/app/lib/provider/yarr/base.py
+++ b/app/lib/provider/yarr/base.py
@@ -8,6 +8,9 @@ import time
 
 log = CPLog(__name__)
 
+
+
+
 class nzbBase(rss):
 
     config = None
@@ -223,6 +226,21 @@ class nzbBase(rss):
                     return id
 
         return self.catBackupId
+
+    def getCatIdNewznab(self, prefQuality, amountCat):
+        ''' Selecting category by quality '''
+        retval = ''
+        for id, quality in self.catIds.iteritems():
+            for q in quality:
+                if q == prefQuality:
+                    if retval != '':
+                        retval = retval + ','
+                    retval = retval + str(id)
+                    amountCat[0]=amountCat[0] + len(self.catIds.get(id))
+        if retval != '':
+            return retval
+        return str(self.catBackupId)
+
 
     def downloadLink(self, id):
         return self.downloadUrl % (id, self.getApiExt())

--- a/app/lib/provider/yarr/sources/newznab.py
+++ b/app/lib/provider/yarr/sources/newznab.py
@@ -19,8 +19,8 @@ class newznab(nzbBase):
 
     catIds = {
         2000: ['brrip'],
-        2010: ['dvdr'],
-        2030: ['cam', 'ts', 'dvdrip', 'tc', 'r5', 'scr'],
+        2010: ['720p', '1080p', 'dvdr', 'cam', 'ts', 'dvdrip', 'tc', 'r5', 'scr'],
+        2030: ['dvdr', 'cam', 'ts', 'dvdrip', 'tc', 'r5', 'scr'],
         2040: ['720p', '1080p']
     }
     catBackupId = 2000
@@ -48,8 +48,9 @@ class newznab(nzbBase):
         results = []
         if not self.enabled() or not self.isAvailable(self.getUrl(self.searchUrl)):
             return results
-
-        catId = self.getCatId(type)
+        amountCat = [0]
+        amountCat[0] = 0
+        catId = self.getCatIdNewznab(type,amountCat)
         arguments = urlencode({
             'imdbid': movie.imdb.replace('tt', ''),
             'cat': catId,
@@ -57,8 +58,8 @@ class newznab(nzbBase):
             'extended': 1
         })
         url = "%s&%s" % (self.getUrl(self.searchUrl), arguments)
-        cacheId = str(movie.imdb) + '-' + str(catId)
-        singleCat = (len(self.catIds.get(catId)) == 1 and catId != self.catBackupId)
+        cacheId = str(movie.imdb) + '-' + catId    
+        singleCat = (amountCat[0] == 1 and catId != str(self.catBackupId))
 
         try:
             cached = False

--- a/app/views/config/index.html
+++ b/app/views/config/index.html
@@ -68,6 +68,13 @@
 						Comma seperated. NZB/Torrents must contain these words. Example: GERMAN, DTS
 					</p>
 				</div>
+				<div class="ctrlHolder">
+					<label>Regex Filter</label>
+					<input type="text" name="global.reqRegex" value="${config.get('global', 'reqRegex')}" class="textInput large"/>
+					<p class="formHint">
+						Regular Expression filter. Ex: 
+					</p>
+				</div>				
 			</fieldset>
 		</div>
 


### PR DESCRIPTION
As described here:
http://help.couchpota.to/discussions/problems/1062-newznab?unresolve=true

I noticed an inconsistency where newsnab is concerned. 
Newsnab , although having categories that only contain 1080p and 720p , or SD media , there are categories , like "others" 2020,  "foreign" 2010, "3D" 2060 which contain similar "qualities" as in the main categories.

For searches to look in multiple categories (foreign and HD for example), they have to be added to the post separated by a comma "&cat=2040,2010" 

I have made a few modifications to newznab.py and base.py to allow for this.

A frontend for letting the user specify which categories contain what for his specific newznab server would be ideal. At it's simplest it would just be a couple of editboxes with something like :

2040 , 1080p , 720p , dvdr
2020, 1080p , 720p 
2010, 1080p, 720p , divx
on each line

Those things haven't been added.

The changes I made are for categories available on nzb.su , i'm sure they're different for others.

I am not planning on keeping a permanent branch going , I set this up so you could consider allowing searches in multiple categories for the same quality in the next release.

Kind regards
Phoenixxl.
