### PR TITLE
Quick fix to let nzbs.org still work using the classic API.

### DIFF
--- a/app/lib/provider/yarr/sources/nzbs.py
+++ b/app/lib/provider/yarr/sources/nzbs.py
@@ -12,10 +12,10 @@ class nzbs(nzbBase):
     """Api for nzbs"""
 
     name = 'NZBs.org'
-    downloadUrl = 'https://nzbs.org/index.php?action=getnzb&nzbid=%s%s'
-    nfoUrl = 'https://nzbs.org/index.php?action=view&nzbid=%s&nfo=1'
-    detailUrl = 'https://nzbs.org/index.php?action=view&nzbid=%s'
-    apiUrl = 'https://nzbs.org/rss.php'
+    downloadUrl = 'https://nzbs.org/classic/index.php?action=getnzb&nzbid=%s%s'
+    nfoUrl = 'https://nzbs.org/classic/index.php?action=view&nzbid=%s&nfo=1'
+    detailUrl = 'https://nzbs.org/classic/index.php?action=view&nzbid=%s'
+    apiUrl = 'https://nzbs.org/classic/rss.php'
 
     catIds = {
         4: ['720p', '1080p'],


### PR DESCRIPTION
nzbs.org has been updated to a new profile and a different API. Nzbs now have a GUID id instead of an integer, etc. But this changeset provides acces to the classic site which is still running (with the old profiles). So it's a temporary fix but it works as advertised. Tested it on my local installation.
