### PR TITLE
Updated iOS app download instructions.

### DIFF
--- a/app/views/config/index.html
+++ b/app/views/config/index.html
@@ -457,7 +457,7 @@
 
 		<div class="group iphone">
 			<fieldset class="inlineLabels">
-				<div>Got a jailbroken iPhone? Get the CouchPotato app on Cydia! <span>(search for "<strong>iCouchPotato</strong>")</span></div>
+				<div>Got a jailbroken iPhone? Get the iCouchPotato app on Cydia! <span>(Add our Cydia repo: "<strong>http://cydia.myrepospace.com/couchpotato/</strong>" and search for "<strong>iCouchPotato</strong>")</span></div>
 				<img src="${baseUrl}media/images/iphone1.png" /><img src="${baseUrl}media/images/iphone2.png" /><img src="${baseUrl}media/images/iphone3.png" />
 				<div>Why isn't it in the normal Appstore you ask? Because Apple is being a bitch!</div>
 			</fieldset>


### PR DESCRIPTION
iCouchPotato has been banned from Cydia's main repo's.
Updated iOS app download instructions.
