### PR TITLE
Fix broken IMDB searching.

### DIFF
--- a/library/imdb/parser/http/__init__.py
+++ b/library/imdb/parser/http/__init__.py
@@ -424,7 +424,8 @@ class IMDbHTTPAccessSystem(IMDbBase):
         if isinstance(ton, unicode):
             ton = ton.encode('utf-8')
         ##params = 'q=%s&%s=on&mx=%s' % (quote_plus(ton), kind, str(results))
-        params = 's=%s;mx=%s;q=%s' % (kind, str(results), quote_plus(ton))
+        ##params = 's=%s;mx=%s;q=%s' % (kind, str(results), quote_plus(ton))
+        params = 's=%s&mx=%s&q=%s' % (kind, str(results), quote_plus(ton))
         if kind == 'ep':
             params = params.replace('s=ep;', 's=tt;ttype=ep;', 1)
         cont = self._retrieve(imdbURL_find % params)
@@ -434,7 +435,8 @@ class IMDbHTTPAccessSystem(IMDbBase):
             return cont
         # The retrieved page contains no results, because too many
         # titles or names contain the string we're looking for.
-        params = 's=%s;q=%s;lm=0' % (kind, quote_plus(ton))
+        ##params = 's=%s;q=%s;lm=0' % (kind, quote_plus(ton))
+        params = 's=%s&q=%s&lm=0' % (kind, quote_plus(ton))
         size = 22528 + results * 512
         return self._retrieve(imdbURL_find % params, size=size)
 


### PR DESCRIPTION
Replacing the ; with & URL parameter separators lets the IMDB search work again.

I realize that v1 is no longer being maintained. However since I'm not the only one still using v1, I wanted to provide a bug fix for anyone looking.
